### PR TITLE
User can now override ansible-vault password file in .dir-locals.el

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ when needed.
     (and (string= (file-name-base) "encrypted") (ansible-vault-mode 1))))
 ```
 
+### Per directory ansible-vault password file
+
+To override ansible-vault password file on a per directory basis:
+first, create a .dir-locals.el file in your directory:
+
+```lisp
+((yaml-mode
+  (ansible-vault-pass-file . "/home/notroot/.ansible-vault/custom_vault_pass")))
+```
+then, if all your vaulted files are prefixed by "vault_", you can load
+ansible-vault-mode in your init file this way:
+
+```lisp
+(add-hook 'hack-local-variables-hook
+          (lambda ()
+            (when (and
+                   (derived-mode-p 'yaml-mode)
+                   (string-prefix-p "vault_" (file-name-base)))
+              (ansible-vault-mode 1))))
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on [GitHub issues][issues]. This

--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -66,26 +66,6 @@ you for a password."
 This will probably change at somepoint in the future and break
 everything and that will be sad.")
 
-(defvar ansible-vault--command
-  (format "%s --vault-password-file='%s' --output=-"
-          ansible-vault-command
-          ansible-vault-pass-file)
-  "Internal variable for `ansible-vault-mode'
-
-Base command used for `ansible-vault' operations.")
-
-(defvar ansible-vault--decrypt-command
-  (format "%s decrypt" ansible-vault--command)
-  "Internal variable for `ansible-vault-mode'
-
-Command used for buffer decryption.")
-
-(defvar ansible-vault--encrypt-command
-  (format "%s encrypt" ansible-vault--command)
-  "Internal variable for `ansible-vault-mode'
-
-Command used for buffer encryption.")
-
 (defvar ansible-vault--point 0
   "Internal variable for `ansible-vault-mode'
 
@@ -114,21 +94,25 @@ is `ansible-vault--file-header'."
         buffer)))
 
 (defun ansible-vault-decrypt-current-buffer ()
-  "In palce decryption of `current-buffer' using `ansible-vault'."
+  "In place decryption of `current-buffer' using `ansible-vault'."
   (let ((inhibit-read-only t))
     (shell-command-on-region
      (point-min) (point-max)
-     ansible-vault--decrypt-command
+     (format "%s --vault-password-file='%s' --output=- decrypt"
+	     ansible-vault-command
+	     ansible-vault-pass-file)
      (current-buffer) t
      (ansible-vault--error-buffer))
     ))
 
 (defun ansible-vault-encrypt-current-buffer ()
-  "In palce encryption of `current-buffer' using `ansible-vault'."
+  "In place encryption of `current-buffer' using `ansible-vault'."
   (let ((inhibit-read-only t))
     (shell-command-on-region
      (point-min) (point-max)
-     ansible-vault--encrypt-command
+     (format "%s --vault-password-file='%s' --output=- encrypt"
+	     ansible-vault-command
+	     ansible-vault-pass-file)
      (current-buffer) t
      (ansible-vault--error-buffer))
     ))


### PR DESCRIPTION
Dear,

As I was not able to override the vault password file variable on a per directory basis I just made this quick modification.

See README.md and changelog for more details.

Regards,
Thomas
