### PR TITLE
Avoid specifying --vault-password-file when not defined

### DIFF
--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -100,10 +100,14 @@ is `ansible-vault--file-header'."
 Ansible vault is called with the same arguments in both the
 encryption and decryption case. Use this to generate the
 substring shared between them."
-  (format "%s --vault-password-file='%s' --output=- %s"
-          ansible-vault-command
-          ansible-vault-pass-file
-          command))
+  (if ansible-vault-pass-file
+      (format "%s --vault-password-file='%s' --output=- %s"
+              ansible-vault-command
+              ansible-vault-pass-file
+              command)
+    (format "%s --output=- %s"
+            ansible-vault-command
+            command)))
 
 (defun ansible-vault-decrypt-current-buffer ()
   "In place decryption of `current-buffer' using `ansible-vault'."


### PR DESCRIPTION
Workaround for this bug:
https://github.com/ansible/ansible/issues/46310

When vault-password-file is already defined in `ansible.cfg`, ansible
gets confused when it is specified on command line as well