### PR TITLE
Add support for the encrypt_string subcommand

### DIFF
--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -129,6 +129,16 @@ substring shared between them."
      (ansible-vault--error-buffer))
     ))
 
+(defun ansible-vault-decrypt-region (start end)
+  "In place decryption of region from START to END using `ansible-vault'."
+  (interactive "r")
+  (let ((inibit-read-only t))
+    (shell-command-on-region
+     start end
+     (ansible-vault--call-command "decrypt")
+     (current-buffer) t
+     (ansible-vault--error-buffer))))
+
 (defvar ansible-vault-mode-map
   (let ((map (make-sparse-keymap)))
     map)

--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -135,6 +135,12 @@ substring shared between them."
   (let ((inhibit-read-only t))
     ;; Restrict the following operations to the selected region.
     (narrow-to-region start end)
+    ;; Delete the vault header, if any.
+    (let ((end-of-first-line (progn (goto-char 1) (end-of-line) (point))))
+      (goto-char 1)
+      (when (re-search-forward (rx line-start "!vault |" line-end) end-of-first-line t)
+        (replace-match "")
+        (kill-line)))
     ;; Delete any leading whitespace in the region.
     (goto-char 1)
     (delete-horizontal-space)

--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -132,12 +132,18 @@ substring shared between them."
 (defun ansible-vault-decrypt-region (start end)
   "In place decryption of region from START to END using `ansible-vault'."
   (interactive "r")
-  (let ((inibit-read-only t))
-    (shell-command-on-region
-     start end
-     (ansible-vault--call-command "decrypt")
-     (current-buffer) t
-     (ansible-vault--error-buffer))))
+  (let ((inhibit-read-only t))
+    ;; Restrict the following operations to the selected region.
+    (narrow-to-region start end)
+    ;; Delete any leading whitespace in the region.
+    (goto-char 1)
+    (delete-horizontal-space)
+    (while (= 0 (forward-line 1))
+      (delete-horizontal-space))
+    ;; Decrypt the region.
+    (ansible-vault-decrypt-current-buffer)
+    ;; Show the rest of the buffer.
+    (widen)))
 
 (defvar ansible-vault-mode-map
   (let ((map (make-sparse-keymap)))

--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -145,6 +145,16 @@ substring shared between them."
     ;; Show the rest of the buffer.
     (widen)))
 
+(defun ansible-vault-encrypt-region (start end)
+  "In place encryption of region from START to END using `ansible-vault'."
+  (interactive "r")
+  (let ((inhitibit-read-only t))
+    (shell-command-on-region
+     start end
+     (ansible-vault--call-command "encrypt_string")
+     (current-buffer) t
+     (ansible-vault--error-buffer))))
+
 (defvar ansible-vault-mode-map
   (let ((map (make-sparse-keymap)))
     map)


### PR DESCRIPTION
[encrypt_string](https://docs.ansible.com/ansible/latest/user_guide/vault.html#use-encrypt-string-to-create-encrypted-variables-to-embed-in-yaml) was added in Ansible 2.3.0:

> The ansible-vault encrypt_string command will encrypt and format a provided string into a format that can be included in ansible-playbook YAML files.

This can be used to encrypt only the secrets within a playbook, leaving the rest of the YAML in plaintext for easier auditing and version control.