### PR TITLE
Fix wrong-type in ansible-vault--call-command

### DIFF
--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -114,20 +114,18 @@ SUBCOMMAND is the \"ansible-vault\" sucommand to use."
   (let ((inhibit-read-only t))
     (shell-command-on-region
      (point-min) (point-max)
-     (ansible-vault--call-command 'decrypt)
+     (ansible-vault--call-command "decrypt")
      (current-buffer) t
-     (ansible-vault--error-buffer))
-    ))
+     (ansible-vault--error-buffer))))
 
 (defun ansible-vault-encrypt-current-buffer ()
   "In place encryption of `current-buffer' using `ansible-vault'."
   (let ((inhibit-read-only t))
     (shell-command-on-region
      (point-min) (point-max)
-     (ansible-vault--call-command 'encrypt)
+     (ansible-vault--call-command "encrypt")
      (current-buffer) t
-     (ansible-vault--error-buffer))
-    ))
+     (ansible-vault--error-buffer))))
 
 (defun ansible-vault-decrypt-region (start end)
   "In place decryption of region from START to END using `ansible-vault'."


### PR DESCRIPTION
Debugger entered--Lisp error: (wrong-type-argument sequencep decrypt)
  ansible-vault--call-command(decrypt)
  ansible-vault-decrypt-current-buffer()
  ansible-vault-mode(1)
  (progn (ansible-vault-mode 1))
  (if (ansible-vault--is-vault-file) (progn (ansible-vault-mode 1)))
  (when (ansible-vault--is-vault-file) (ansible-vault-mode 1))
  ansible-vault-mode-maybe()
  run-hooks(change-major-mode-after-body-hook text-mode-hook yaml-mode-hook)
  apply(run-hooks (change-major-mode-after-body-hook text-mode-hook yaml-mode-hook))
  run-mode-hooks(yaml-mode-hook)
  yaml-mode()