### PR TITLE
fix ansible-vault argument order

### DIFF
--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -103,11 +103,11 @@ generates the shell string for any such command.
 
 SUBCOMMAND is the \"ansible-vault\" sucommand to use."
   (concat
-   ansible-vault-command " "
+   ansible-vault-command " " subcommand " "
    (when ansible-vault-pass-file
      (format "--vault-password-file='%s' " ansible-vault-pass-file))
    "--output=- "
-   subcommand))
+   ))
 
 (defun ansible-vault-decrypt-current-buffer ()
   "In place decryption of `current-buffer' using `ansible-vault'."


### PR DESCRIPTION
the "subcommand" is expected to be the first parameter handed over
to ansible-vault (since version 2.9.0)