### PR TITLE
View encrypted contents by default, only encrypt if needed

### DIFF
--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -121,14 +121,21 @@ is `ansible-vault--file-header'."
   "Generate Ansible Vault command with common args and SUBCOMMAND.
 
 The command \"ansible-vault\" is called with the same arguments whether
-decrypting, encrypting a file, or encrypting a string.  This function
-generates the shell string for any such command.
+decrypting, encrypting a file, or encrypting a string; it's only called
+with a different set of arguments when performing \"view\" on the
+current buffer.
+This happens as the \"view\" subcommand expects a file as argument.
+This function generates the shell string for any such command.
 
 SUBCOMMAND is the \"ansible-vault\" subcommand to use.
 
 PASS-FILE is the path to the vault password file on disk."
-  (concat (format "%s %s --output=-" ansible-vault-command subcommand) " "
-          (when pass-file (format "--vault-password-file=%S" pass-file))))
+  (if (string= subcommand "view")
+      (concat (format "%s %s" ansible-vault-command subcommand) " "
+              (buffer-file-name) " "
+          (when pass-file (format "--vault-password-file=%S" pass-file)))
+    (concat (format "%s %s --output=-" ansible-vault-command subcommand) " "
+          (when pass-file (format "--vault-password-file=%S" pass-file)))))
 
 (defun ansible-vault--process-config-files ()
   "Attempts to discover if vault_password_file is defined in any
@@ -253,6 +260,10 @@ ERROR-BUFFER defaults to `ansible-vault--error-buffer'."
   "In place encryption of `current-buffer' using `ansible-vault'."
   (ansible-vault--execute-on-region "encrypt"))
 
+(defun ansible-vault-view-current-buffer ()
+  "In place view of `current-buffer' using `ansible-vault'."
+  (ansible-vault--execute-on-region "view"))
+
 (defun ansible-vault-decrypt-region (start end)
   "In place decryption of region from START to END using `ansible-vault'."
   (interactive "r")
@@ -337,9 +348,9 @@ Ensures deletion of ansible-vault generated password files."
         ;; Disable auto-save
         (if auto-save-default (auto-save-mode -1))
 
-        ;; Decrypt the current buffer first if it needs to be
+        ;; Decrypt the current buffer via the 'view' subcommand
         (when (ansible-vault--is-vault-file)
-          (ansible-vault-decrypt-current-buffer)
+          (ansible-vault-view-current-buffer)
           (set-buffer-modified-p nil))
 
         ;; Add mode hooks
@@ -353,9 +364,11 @@ Ensures deletion of ansible-vault generated password files."
     (remove-hook 'before-save-hook 'ansible-vault--before-save-hook t)
     (remove-hook 'kill-buffer-hook 'ansible-vault--kill-buffer-hook t)
 
-    ;; Re-encrypt the current buffer
-    (if (not (ansible-vault--is-vault-file))
-        (ansible-vault-encrypt-current-buffer))
+    ;; Only re-encrypt the buffer if buffer is changed; otherwise revert
+    ;; to on-disk contents.
+    (if (and (buffer-modified-p) (not (ansible-vault--is-vault-file)))
+        (ansible-vault-encrypt-current-buffer)
+      (revert-buffer nil t nil))
 
     ;; Clean up password state
     (ansible-vault--flush-password)

--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -121,21 +121,14 @@ is `ansible-vault--file-header'."
   "Generate Ansible Vault command with common args and SUBCOMMAND.
 
 The command \"ansible-vault\" is called with the same arguments whether
-decrypting, encrypting a file, or encrypting a string; it's only called
-with a different set of arguments when performing \"view\" on the
-current buffer.
-This happens as the \"view\" subcommand expects a file as argument.
-This function generates the shell string for any such command.
+decrypting, encrypting a file, or encrypting a string.  This function
+generates the shell string for any such command.
 
 SUBCOMMAND is the \"ansible-vault\" subcommand to use.
 
 PASS-FILE is the path to the vault password file on disk."
-  (if (string= subcommand "view")
-      (concat (format "%s %s" ansible-vault-command subcommand) " "
-              (buffer-file-name) " "
-          (when pass-file (format "--vault-password-file=%S" pass-file)))
-    (concat (format "%s %s --output=-" ansible-vault-command subcommand) " "
-          (when pass-file (format "--vault-password-file=%S" pass-file)))))
+  (concat (format "%s %s --output=-" ansible-vault-command subcommand) " "
+          (when pass-file (format "--vault-password-file=%S" pass-file))))
 
 (defun ansible-vault--process-config-files ()
   "Attempts to discover if vault_password_file is defined in any
@@ -260,10 +253,6 @@ ERROR-BUFFER defaults to `ansible-vault--error-buffer'."
   "In place encryption of `current-buffer' using `ansible-vault'."
   (ansible-vault--execute-on-region "encrypt"))
 
-(defun ansible-vault-view-current-buffer ()
-  "In place view of `current-buffer' using `ansible-vault'."
-  (ansible-vault--execute-on-region "view"))
-
 (defun ansible-vault-decrypt-region (start end)
   "In place decryption of region from START to END using `ansible-vault'."
   (interactive "r")
@@ -348,9 +337,9 @@ Ensures deletion of ansible-vault generated password files."
         ;; Disable auto-save
         (if auto-save-default (auto-save-mode -1))
 
-        ;; Decrypt the current buffer via the 'view' subcommand
+        ;; Decrypt the current buffer first if it needs to be
         (when (ansible-vault--is-vault-file)
-          (ansible-vault-view-current-buffer)
+          (ansible-vault-decrypt-current-buffer)
           (set-buffer-modified-p nil))
 
         ;; Add mode hooks


### PR DESCRIPTION
Please consider the following scenario:
When your ansible inventory is under version control and you just want to check out the value of some variable, the current implementation will change the resulting file even though no changes were made to the file.  The file would be seen as having been changed.  Instead:
* Use the `view` subcommand to decrypt the file contents instead of
  `decrypt` in order not to alter the file if there isn't a need to
  do so
* Only encrypt the buffer if buffer is changed; otherwise, just revert
  to the on-disk file w/o any confirmation from the user since the
  intention was not to alter the file but maybe just to take a look at
  some values & later on close the file.