### PR TITLE
Improve ansible.cfg lookup

### DIFF
--- a/ansible-vault.el
+++ b/ansible-vault.el
@@ -221,7 +221,7 @@ commandline flag for it."
   (let ((config-file
          (seq-find (lambda (file) (and file (file-readable-p file) file))
                    (list (getenv "ANSIBLE_CONFIG")
-                         "ansible.cfg"
+                         (expand-file-name "ansible.cfg" (locate-dominating-file (buffer-file-name) "ansible.cfg"))
                          "~/.ansible.cfg"
                          "/etc/ansible/ansible.cfg"))))
     (unless (= (length config-file) 0)


### PR DESCRIPTION
Hey, I added a simple lookup for upper directories for ansible.cfg.

Usually ansible.cfg is located in the root of project, and encrypted files are somewhere else, i.e. under vars/ directory.

The function locate-dominating-file is from emacs's file.el and therefore is always present.

Tested in my infrastructure repo and outside of it for all corner cases. Works. Please accept this PR and release it into melpa. Thanks.